### PR TITLE
Make serve_file() take a name

### DIFF
--- a/WP_Serve_File.php
+++ b/WP_Serve_File.php
@@ -57,8 +57,8 @@ class WP_Serve_File {
     return $file;
   }
 
-  public function serve_file() {
-    $name = $_GET['wpservefile_file'];
+  public function serve_file($name = '') {
+    $name = $name ? $name : $_GET['wpservefile_file'];
 
     $file = get_transient('wpservefile_files_' . $name);
     if (empty($file)) {


### PR DESCRIPTION
Make `serve_file()` take a name falling back to `$_GET`. This will enable `serve_file` to be used by another function/class.